### PR TITLE
*: Rename selectPrepareAndSecondary to selectPrimaryAndSecondries

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -167,7 +167,7 @@ func (txn *Txn) Commit() error {
 		return nil
 	}
 
-	txn.selectPrepareAndSecondary()
+	txn.selectPrimaryAndSecondaries()
 	err := txn.prewritePrimary()
 	if err != nil {
 		return errors.Trace(err)
@@ -260,7 +260,7 @@ func (txn *Txn) commitPrimary() error {
 		txn.startTs, txn.commitTs, txn.primaryRowOffset)
 }
 
-func (txn *Txn) selectPrepareAndSecondary() {
+func (txn *Txn) selectPrimaryAndSecondaries() {
 	txn.secondary = nil
 	for tblName, rowMutations := range txn.mutationCache.mutations {
 		for _, rowMutation := range rowMutations {

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -201,7 +201,7 @@ func (s *TransactionTestSuit) TestLockRow(c *C) {
 	err := tx.LockRow(themisTestTableName, row)
 	c.Assert(err, Equals, nil)
 
-	tx.selectPrepareAndSecondary()
+	tx.selectPrimaryAndSecondaries()
 	err = tx.prewritePrimary()
 	c.Assert(err, Equals, nil)
 	colMap := make(map[string]string)


### PR DESCRIPTION
See: https://github.com/pingcap/themis/blob/master/themis-client/src/main/java/org/apache/hadoop/hbase/themis/Transaction.java#L407

This function is used to select primary lock and secondary locks. "selectPrepareAndSecondary" is not a good name.